### PR TITLE
Fix repository names throughout the project

### DIFF
--- a/.github/workflows/docgenerator.yml
+++ b/.github/workflows/docgenerator.yml
@@ -11,14 +11,14 @@ jobs:
         fetch-depth: 1
 
     - name: Set MASVS_VERSION to env 
-      run: echo "MASVS_VERSION=$(curl -s https://api.github.com/repos/OWASP/owasp-masvs/tags | jq '.[0].name' | sed 's/\"//g')" >> $GITHUB_ENV
+      run: echo "MASVS_VERSION=$(curl -s https://api.github.com/repos/OWASP/masvs/tags | jq '.[0].name' | sed 's/\"//g')" >> $GITHUB_ENV
 
     - name: Set DEV MASVS_VERSION if it's not a tag
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       run: echo "MASVS_VERSION=${{env.MASVS_VERSION}}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
     - name: Get Latest MASTG Release Tag
-      run: echo "MASTG_VERSION=$(curl -s https://api.github.com/repos/OWASP/owasp-mastg/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_ENV
+      run: echo "MASTG_VERSION=$(curl -s https://api.github.com/repos/OWASP/mastg/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_ENV
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## V1.3.1 and newer
 
-All our Changelogs are available online at the OWASP MASVS GitHub repository, see the [Releases page](https://github.com/OWASP/owasp-masvs/releases).
+All our Changelogs are available online at the OWASP MASVS GitHub repository, see the [Releases page](https://github.com/OWASP/masvs/releases).
 
 ## V1.3 - 13 May 2021
 
-We are proud to announce the introduction of a new document build pipeline, which is a major milestone for our project. The build pipeline is based on [Pandocker](https://github.com/dalibo/pandocker) and [Github Actions](https://github.com/OWASP/owasp-masvs/tree/master/.github/workflows).
+We are proud to announce the introduction of a new document build pipeline, which is a major milestone for our project. The build pipeline is based on [Pandocker](https://github.com/dalibo/pandocker) and [Github Actions](https://github.com/OWASP/masvs/tree/master/.github/workflows).
 This significantly reduces the time spent on creating new releases and will also be the foundation for the OWASP MSTG and will be made available for the OWASP ASVS project.
 
 ### Changes

--- a/Document/02-Frontispiece.md
+++ b/Document/02-Frontispiece.md
@@ -6,7 +6,7 @@ The OWASP Mobile Application Security Verification Standard (MASVS) is the indus
 
 The OWASP MASVS is the result of years of community effort and industry feedback. We thank all the contributors who have helped shape this standard. We welcome your feedback on the OWASP MASVS at any time, especially as you apply it to your own organization and mobile app development projects. Getting inputs from a variety of mobile app developers will help us improve and update the standard which is revised periodically based on your inputs and feedback.
 
-You can provide feedback using GitHub Discussions in the OWASP MASVS repo <https://github.com/OWASP/owasp-masvs/discussions>, or contact the project leads directly <https://mas.owasp.org/contact/>.
+You can provide feedback using GitHub Discussions in the OWASP MASVS repo <https://github.com/OWASP/masvs/discussions>, or contact the project leads directly <https://mas.owasp.org/contact/>.
 
 The OWASP MASVS and MASTG are trusted by the following platform providers and standardization, governmental and educational institutions. [Learn more](https://mas.owasp.org/MASTG/Intro/0x02b-MASVS-MASTG-Adoption/).
 
@@ -58,7 +58,7 @@ While both the MASVS and the MASTG are created and maintained by the community o
 
 All our Changelogs are available online at the OWASP MASVS GitHub repository, see the Releases page:
 
-<https://github.com/OWASP/owasp-masvs/releases>
+<https://github.com/OWASP/masvs/releases>
 
 ## Copyright and License
 

--- a/Document/CHANGELOG.md
+++ b/Document/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## V1.3.1 and newer
 
-All our Changelogs are available online at the OWASP MASVS GitHub repository, see the [Releases page](https://github.com/OWASP/owasp-masvs/releases).
+All our Changelogs are available online at the OWASP MASVS GitHub repository, see the [Releases page](https://github.com/OWASP/masvs/releases).
 
 ## V1.3 - 13 May 2021
 
-We are proud to announce the introduction of a new document build pipeline, which is a major milestone for our project. The build pipeline is based on [Pandocker](https://github.com/dalibo/pandocker) and [Github Actions](https://github.com/OWASP/owasp-masvs/tree/master/.github/workflows).
+We are proud to announce the introduction of a new document build pipeline, which is a major milestone for our project. The build pipeline is based on [Pandocker](https://github.com/dalibo/pandocker) and [Github Actions](https://github.com/OWASP/masvs/tree/master/.github/workflows).
 This significantly reduces the time spent on creating new releases and will also be the foundation for the OWASP MSTG and will be made available for the OWASP ASVS project.
 
 ### Changes

--- a/Document/Mobile_App_Security_Model.md
+++ b/Document/Mobile_App_Security_Model.md
@@ -1,0 +1,82 @@
+# Mobile Application Security Model
+
+The MAS project defines several security testing profiles that businesses and developers can use to evaluate and improve the security of their mobile applications. However, it’s important to note that implementing these profiles fully or partially should be a risk-based decision made in consultation with business owners.
+
+![MAS Profiles](images/masvs-levels-new.jpg)\
+
+**MAS-L1 - Baseline Security:**
+
+MAS-L1 contains generic security controls recommended for all mobile apps. This profile considers co-installed apps as well as network-based attackers but assumes that the security controls of the mobile operating system are intact and that the end user is not viewed as a potential adversary. Fulfilling these controls results in a secure app that follows best practices and avoids common vulnerabilities.
+
+**MAS-L2 - Defense-in-Depth:**
+
+MAS-L2 adds additional defense-in-depth controls to protect against more sophisticated attacks. This profile assumes that the security controls of the mobile operating system might not be intact and that the app user can be considered as a potential adversary. It is appropriate for apps handling highly sensitive data, such as mobile banking apps.
+
+**MAS-R - Resilience:**
+
+MAS-R contains software protection controls to impede specific client-side threats where the end user is malicious and/or the mobile OS is compromised. These threats include tampering, modding, or reverse engineering to extract sensitive code or data. This level is applicable to apps that need to protect intellectual property such as gaming apps and enterprise apps that handle confidential or proprietary information.
+
+**Note that MAS-R controls can ultimately be bypassed and should never be used as a replacement for proper security controls. Instead, they are intended to add additional threat-specific protective controls to apps that also fulfill the MASVS controls in MAS-L1 or MAS-L2.**
+
+## Recommended Use
+
+A risk assessment should be the first step before applying the MASVS. Apps can be verified against the different MAS profiles based on prior risk assessment and overall level of security required which will determine which MAS profile or profiles should be applied to the app. Note that combinations of profiles are possible:
+
+- MAS-L1
+- MAS-L1 + MAS-R
+- MAS-L2
+- MAS-L2 + MAS-R
+
+The different combinations reflect different grades of security and resilience. Threat model is essential to determine not only the profiles to be applied but also the controls and risks (represented by tests in the MASTG) that are applicable. **When testing using a MAS profile you don't have to apply each and every test**
+
+The goal is to allow for flexibility: For example, a mobile game might not warrant adding MAS-L2 security controls such as 2-factor authentication for usability reasons, but have a strong business need for tamper prevention.
+
+## The Security Trade-offs
+
+Adding more security controls from higher MAS profiles can make the app more secure, but it also may increase the cost of development and may affect the user experience negatively.
+
+### Security vs Cost
+
+In general, MAS profiles should be used whenever it makes sense from a risk vs. cost perspective (i.e., where the potential loss caused by a compromise of confidentiality or integrity is higher than the cost incurred by the additional security controls). The potential loss is the negative impact that a compromise of confidentiality or integrity would have on the app's users, data, functionality, reputation, or revenue. The cost of security controls is the amount of time, money, and resources that are needed to implement and maintain the security features. You need to estimate how likely it is that your app will be attacked, how severe the consequences would be if your app's data was compromised, and how much value your app provides to your users and your business.
+
+For example, if you are developing a mobile app that handles sensitive health data of your users, you might want to use MAS-L2 to ensure strong encryption and authentication features. The potential loss caused by a data breach would be very high in terms of user privacy, trust, and legal liability. The cost of implementing these security controls would be justified by the value and reputation of your app.
+
+On the other hand, if you are developing a mobile app that only displays public information such as weather forecasts or news articles, complying with MAS-L1 is usually enough. The potential loss caused by a data breach would be low in terms of user privacy and trust. The cost of implementing these security controls would not be worth the marginal benefit for your app.
+
+### Security vs Usability
+
+Some security features may make the app more difficult or inconvenient to use, which may affect user satisfaction or retention. For example, requiring complex passwords or frequent verification may increase security, but also frustrate users who want a smooth and fast experience. Developers should predict and resolve conflicts between security and usability requirements during the app design process.
+
+### Security vs Privacy
+
+Some security features may require accessing or collecting user data, which may raise privacy concerns. For example, using SMS as multi-factor authentication may improve security, but also expose sensitive personal information (the user telephone number). Developers should balance the security and privacy needs of their users and comply with relevant laws and regulations.
+
+### Privacy vs Value
+
+Some apps may offer more value or functionality to users in exchange for accessing or sharing their data, which may compromise their privacy. For example, some apps may provide personalized recommendations or discounts based on user preferences or location data, but also expose users to targeted ads or third-party tracking. Developers should be aware that users will weigh the benefits and risks of downloading and using such apps based on their own privacy concerns.
+
+## Examples of Use
+
+### MASVS-L1
+
+- All mobile apps. MASVS-L1 lists security best practices that can be followed with a reasonable impact on development cost and user experience. Apply the controls in MASVS-L1 for any app that don't qualify for one of the higher levels.
+
+### MASVS-L2
+
+- Health-Care Industry: Mobile apps that store personally identifiable information that can be used for identity theft, fraudulent payments, or a variety of fraud schemes. For the US healthcare sector, compliance considerations include the Health Insurance Portability and Accountability Act (HIPAA) Privacy, Security, Breach Notification Rules and Patient Safety Rule.
+
+- Financial Industry: Apps that enable access to highly sensitive information like credit card numbers, personal information, or allow the user to move funds. These apps warrant additional security controls to prevent fraud. Financial apps need to ensure compliance to the Payment Card Industry Data Security Standard (PCI DSS), Gramm Leech Bliley Act and Sarbanes-Oxley Act (SOX).
+
+### MASVS L1+R
+
+- Mobile apps where Intellectual Property (IP) protection is a business goal. The resilience controls listed in MASVS-R can be used to increase the effort needed to obtain the original source code and to impede tampering / cracking.
+
+- Gaming Industry: Games with an essential need to prevent modding and cheating, such as competitive online games. Cheating is an important issue in online games, as a large amount of cheaters leads to a disgruntled player base and can ultimately cause a game to fail. MASVS-R provides basic anti-tampering controls to help increase the effort for cheaters.
+
+### MASVS L2+R
+
+- Financial Industry: Online banking apps that allow the user to move funds, where techniques such as code injection and instrumentation on compromised devices pose a risk. In this case, controls from MASVS-R can be used to impede tampering, raising the bar for malware authors.
+
+- All mobile apps that, by design, need to store sensitive data on the mobile device, and at the same time must support a wide range of devices and operating system versions. In this case, resilience controls can be used as a defense-in-depth measure to increase the effort for attackers aiming to extract the sensitive data.
+
+- Apps with in-app purchases should ideally use server-side and MASVS-L2 controls to protect paid content. However, there may be cases where there is no possibility to use server-side protection. In those cases, MASVS-R controls should be additionally applied in order to increase the reversing and/or tampering effort.

--- a/OWASP_MASVS.yaml
+++ b/OWASP_MASVS.yaml
@@ -1,0 +1,209 @@
+metadata:
+  title: Mobile Application Security Verification Standard (MASVS)
+  remarks: The OWASP MASVS (Mobile Application Security Verification Standard) is the industry standard for mobile app security. It can be used by mobile software architects and developers seeking to develop secure mobile apps, as well as security testers to ensure completeness and consistency of test results.
+  version: vx.x.x
+groups:
+- id: MASVS-STORAGE
+  index: 1
+  title: Storage
+  description: '
+
+    Mobile applications handle a wide variety of sensitive data, such as personally identifiable information (PII), cryptographic material, secrets, and API keys, that often need to be stored locally. This sensitive data may be stored in private locations, such as the app''s internal storage, or in public folders that are accessible by the user or other apps installed on the device. However, sensitive data can also be unintentionally stored or exposed to publicly accessible locations, typically as a side-effect of using certain APIs or system capabilities such as backups or logs.
+
+
+    This category is designed to help developers ensure that any sensitive data intentionally stored by the app is properly protected, regardless of the target location. It also covers unintentional leaks that can occur due to improper use of APIs or system capabilities.
+
+    '
+  controls:
+  - id: MASVS-STORAGE-1
+    statement: The app securely stores sensitive data.
+    description: Apps handle sensitive data coming from many sources such as the user, the backend, system services or other apps on the device and usually need to store it locally. The storage locations may be private to the app (e.g. its internal storage) or be public and therefore accessible by the user or other installed apps (e.g. public folders such as Downloads). This control ensures that any sensitive data that is intentionally stored by the app is properly protected independently of the target location.
+  - id: MASVS-STORAGE-2
+    statement: The app prevents leakage of sensitive data.
+    description: There are cases when sensitive data is unintentionally stored or exposed to publicly accessible locations; typically as a side-effect of using certain APIs, system capabilities such as backups or logs. This control covers this kind of unintentional leaks where the developer actually has a way to prevent it.
+- id: MASVS-CRYPTO
+  index: 2
+  title: Cryptography
+  description: '
+
+    Cryptography is essential for mobile apps because mobile devices are highly portable and can be easily lost or stolen. This means that an attacker who gains physical access to a device can potentially access all the sensitive data stored on it, including passwords, financial information, and personally identifiable information. Cryptography provides a means of protecting this sensitive data by encrypting it so that it cannot be easily read or accessed by an unauthorized user.
+
+
+    The purpose of the controls in this category is to ensure that the verified app uses cryptography according to industry best practices, which are typically defined in external standards such as [NIST.SP.800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final) and [NIST.SP.800-57](https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final). This category also focuses on the management of cryptographic keys throughout their lifecycle, including key generation, storage, and protection. Poor key management can compromise even the strongest cryptography, so it is crucial for developers to follow the recommended best practices to ensure the security of their users'' sensitive data.
+
+    '
+  controls:
+  - id: MASVS-CRYPTO-1
+    statement: The app employs current strong cryptography and uses it according to industry best practices.
+    description: Cryptography plays an especially important role in securing the user's data - even more so in a mobile environment, where attackers having physical access to the user's device is a likely scenario. This control covers general cryptography best practices, which are typically defined in external standards.
+  - id: MASVS-CRYPTO-2
+    statement: The app performs key management according to industry best practices.
+    description: Even the strongest cryptography would be compromised by poor key management. This control covers the management of cryptographic keys throughout their lifecycle, including key generation, storage and protection.
+- id: MASVS-AUTH
+  index: 3
+  title: Authentication and Authorization
+  description: '
+
+    Authentication and authorization are essential components of most mobile apps, especially those that connect to a remote service. These mechanisms provide an added layer of security and help prevent unauthorized access to sensitive user data. Although the enforcement of these mechanisms must be on the remote endpoint, it is equally important for the app to follow relevant best practices to ensure the secure use of the involved protocols.
+
+
+    Mobile apps often use different forms of authentication, such as biometrics, PIN, or multi-factor authentication code generators, to validate user identity. These mechanisms must be implemented correctly to ensure their effectiveness in preventing unauthorized access. Additionally, some apps may rely solely on local app authentication and may not have a remote endpoint. In such cases, it is critical to ensure that local authentication mechanisms are secure and implemented following industry best practices.
+
+
+    The controls in this category aim to ensure that the app implements authentication and authorization mechanisms securely, protecting sensitive user information and preventing unauthorized access. It is important to note that the security of the remote endpoint should also be validated using industry standards such as the [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/).
+
+    '
+  controls:
+  - id: MASVS-AUTH-1
+    statement: The app uses secure authentication and authorization protocols and follows the relevant best practices.
+    description: Most apps connecting to a remote endpoint require user authentication and also enforce some kind of authorization. While the enforcement of these mechanisms must be on the remote endpoint, the apps also have to ensure that it follows all the relevant best practices to ensure a secure use of the involved protocols.
+  - id: MASVS-AUTH-2
+    statement: The app performs local authentication securely according to the platform best practices.
+    description: Many apps allow users to authenticate via biometrics or a local PIN code. These authentication mechanisms need to be correctly implemented. Additionally, some apps might not have a remote endpoint, and rely fully on local app authentication.
+  - id: MASVS-AUTH-3
+    statement: The app secures sensitive operations with additional authentication.
+    description: Some additional form of authentication is often desirable for sensitive actions inside the app. This can be done in different ways (biometric, pin, MFA code generator, email, deep links, etc) and they all need to be implemented securely.
+- id: MASVS-NETWORK
+  index: 4
+  title: Network Communication
+  description: '
+
+    Secure networking is a critical aspect of mobile app security, particularly for apps that communicate over the network. In order to ensure the confidentiality and integrity of data in transit, developers typically rely on encryption and authentication of the remote endpoint, such as through the use of TLS. However, there are numerous ways in which a developer may accidentally disable the platform secure defaults or bypass them entirely by utilizing low-level APIs or third-party libraries.
+
+
+    This category is designed to ensure that the mobile app sets up secure connections under any circumstances. Specifically, it focuses on verifying that the app establishes a secure, encrypted channel for network communication. Additionally, this category covers situations where a developer may choose to trust only specific Certificate Authorities (CAs), which is commonly referred to as certificate pinning or public key pinning.
+
+    '
+  controls:
+  - id: MASVS-NETWORK-1
+    statement: The app secures all network traffic according to the current best practices.
+    description: Ensuring data privacy and integrity of any data in transit is critical for any app that communicates over the network. This is typically done by encrypting data and authenticating the remote endpoint, as TLS does. However, there are many ways for a developer to disable the platform secure defaults, or bypass them completely by using low-level APIs or third-party libraries. This control ensures that the app is in fact setting up secure connections in any situation.
+  - id: MASVS-NETWORK-2
+    statement: The app performs identity pinning for all remote endpoints under the developer's control.
+    description: Instead of trusting all the default root CAs of the framework or device, this control will make sure that only very specific CAs are trusted. This practice is typically called certificate pinning or public key pinning.
+- id: MASVS-PLATFORM
+  index: 5
+  title: Platform Interaction
+  description: '
+
+    The security of mobile apps heavily depends on their interaction with the mobile platform, which often involves exposing data or functionality intentionally through the use of platform-provided inter-process communication (IPC) mechanisms and WebViews to enhance the user experience. However, these mechanisms can also be exploited by attackers or other installed apps, potentially compromising the app''s security.
+
+
+    Furthermore, sensitive data, such as passwords, credit card details, and one-time passwords in notifications, is often displayed in the app''s user interface. It is essential to ensure that this data is not unintentionally leaked through platform mechanisms such as auto-generated screenshots or accidental disclosure through shoulder surfing or device sharing.
+
+
+    This category comprises controls that ensure the app''s interactions with the mobile platform occur securely. These controls cover the secure use of platform-provided IPC mechanisms, WebView configurations to prevent sensitive data leakage and functionality exposure, and secure display of sensitive data in the app''s user interface. By implementing these controls, mobile app developers can safeguard sensitive user information and prevent unauthorized access by attackers.
+
+    '
+  controls:
+  - id: MASVS-PLATFORM-1
+    statement: The app uses IPC mechanisms securely.
+    description: Apps typically use platform provided IPC mechanisms to intentionally expose data or functionality. Both installed apps and the user are able to interact with the app in many different ways. This control ensures that all interactions involving IPC mechanisms happen securely.
+  - id: MASVS-PLATFORM-2
+    statement: The app uses WebViews securely.
+    description: WebViews are typically used by apps that have a need for increased control over the UI. This control ensures that WebViews are configured securely to prevent sensitive data leakage as well as sensitive functionality exposure (e.g. via JavaScript bridges to native code).
+  - id: MASVS-PLATFORM-3
+    statement: The app uses the user interface securely.
+    description: Sensitive data has to be displayed in the UI in many situations (e.g. passwords, credit card details, OTP codes in notifications). This control ensures that this data doesn't end up being unintentionally leaked due to platform mechanisms such as auto-generated screenshots or accidentally disclosed via e.g. shoulder surfing or sharing the device with another person.
+- id: MASVS-CODE
+  index: 6
+  title: Code Quality
+  description: '
+
+    Mobile apps have many data entry points, including the UI, IPC, network, and file system, which might receive data that has been inadvertently modified by untrusted actors. By treating this data as untrusted input and properly verifying and sanitizing it before use, developers can prevent classical injection attacks, such as SQL injection, XSS, or insecure deserialization. However, other common coding vulnerabilities, such as memory corruption flaws, are hard to detect in penetration testing but easy to prevent with secure architecture and coding practices. Developers should follow best practices such as the [OWASP Software Assurance Maturity Model (SAMM)](https://owaspsamm.org/model/) and [NIST.SP.800-218 Secure Software Development Framework (SSDF)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-218.pdf) to avoid introducing these flaws in the first place.
+
+
+    This category covers coding vulnerabilities that arise from external sources such as app data entry points, the OS, and third-party software components. Developers should verify and sanitize all incoming data to prevent injection attacks and bypass of security checks. They should also enforce app updates and ensure that the app runs up-to-date platforms to protect users from known vulnerabilities.
+
+    '
+  controls:
+  - id: MASVS-CODE-1
+    statement: The app requires an up-to-date platform version.
+    description: Every release of the mobile OS includes security patches and new security features. By supporting older versions, apps stay vulnerable to well-known threats. This control ensures that the app is running on an up-to-date platform version so that users have the latest security protections.
+  - id: MASVS-CODE-2
+    statement: The app has a mechanism for enforcing app updates.
+    description: Sometimes critical vulnerabilities are discovered in the app when it is already in production. This control ensures that there is a mechanism to force the users to update the app before they can continue using it.
+  - id: MASVS-CODE-3
+    statement: The app only uses software components without known vulnerabilities.
+    description: To be truly secure, a full whitebox assessment should have been performed on all app components. However, as it usually happens with e.g. for third-party components this is not always feasible and not typically part of a penetration test. This control covers "low-hanging fruit" cases, such as those that can be detected just by scanning libraries for known vulnerabilities.
+  - id: MASVS-CODE-4
+    statement: The app validates and sanitizes all untrusted inputs.
+    description: Apps have many data entry points including the UI, IPC, the network, the file system, etc. This incoming data might have been inadvertently modified by untrusted actors and may lead to bypass of critical security checks as well as classical injection attacks such as SQL injection, XSS or insecure deserialization. This control ensures that this data is treated as untrusted input and is properly verified and sanitized before it's used.
+- id: MASVS-RESILIENCE
+  index: 7
+  title: Resilience Against Reverse Engineering and Tampering
+  description: '
+
+    Defense-in-depth measures such as code obfuscation, anti-debugging, anti-tampering, etc. are important to increase app resilience against reverse engineering and specific client-side attacks. They add multiple layers of security controls to the app, making it more difficult for attackers to successfully reverse engineer and extract valuable intellectual property or sensitive data from it, which could result in:
+
+
+    - The theft or compromise of valuable business assets such as proprietary algorithms, trade secrets, or customer data
+
+    - Significant financial losses due to loss of revenue or legal action
+
+    - Legal and reputational damage due to breach of contracts or regulations
+
+    - Damage to brand reputation due to negative publicity or customer dissatisfaction
+
+
+    The controls in this category aim to ensure that the app is running on a trusted platform, prevent tampering at runtime and ensure the integrity of the app''s intended functionality. Additionally, the controls impede comprehension by making it difficult to figure out how the app works using static analysis and prevent dynamic analysis and instrumentation that could allow an attacker to modify the code at runtime.
+
+
+    However, note that the lack of any of these measures does not necessarily cause vulnerabilities - instead, they add threat-specific additional protection to apps which must also fulfil the rest of the OWASP MASVS security controls according to their specific threat models.
+
+    '
+  controls:
+  - id: MASVS-RESILIENCE-1
+    statement: The app validates the integrity of the platform.
+    description: Running on a platform that has been tampered with can be very dangerous for apps, as this may disable certain security features, putting the data of the app at risk. Trusting the platform is essential for many of the MASVS controls relying on the platform being secure (e.g. secure storage, biometrics, sandboxing, etc.). This control tries to validate that the OS has not been compromised and its security features can thus be trusted.
+  - id: MASVS-RESILIENCE-2
+    statement: The app implements anti-tampering mechanisms.
+    description: Apps run on a user-controlled device, and without proper protections it's relatively easy to run a modified version locally (e.g. to cheat in a game, or enable premium features without paying), or upload a backdoored version of it to third-party app stores. This control tries to ensure the integrity of the app's intended functionality by preventing modifications to the original code and resources.
+  - id: MASVS-RESILIENCE-3
+    statement: The app implements anti-static analysis mechanisms.
+    description: Understanding the internals of an app is typically the first step towards tampering with it (either dynamically, or statically). This control tries to impede comprehension by making it as difficult as possible to figure out how an app works using static analysis.
+  - id: MASVS-RESILIENCE-4
+    statement: The app implements anti-dynamic analysis techniques.
+    description: Sometimes pure static analysis is very difficult and time consuming so it typically goes hand in hand with dynamic analysis. Observing and manipulating an app during runtime makes it much easier to decipher its behavior. This control aims to make it as difficult as possible to perform dynamic analysis, as well as prevent dynamic instrumentation which could allow an attacker to modify the code at runtime.
+- id: MASVS-PRIVACY
+  index: 8
+  title: Privacy
+  description: '
+
+    The main goal of MASVS-PRIVACY is to provide a **baseline for user privacy**. It is not intended to cover all aspects of user privacy, especially when other standards and regulations such as ENISA or the GDPR already do that. We focus on the app itself, looking at what can be tested using information that''s publicly available or found within the app through methods like static or dynamic analysis.
+
+
+    While some associated tests can be automated, others necessitate manual intervention due to the nuanced nature of privacy. For example, if an app collects data that it didn''t mention in the app store or its privacy policy, it takes careful manual checking to spot this.
+
+
+    > **Note on "Data Collection and Sharing"**:For the MASTG tests, we treat "Collect" and "Share" in a unified manner. This means that whether the app is sending data to another server or transferring it to another app on the device, we view it as data that''s potentially leaving the user''s control. Validating what happens to the data on remote endpoints is challenging and often not feasible due to access restrictions and the dynamic nature of server-side operations. Therefore, this issue is outside of the scope of the MASVS.
+
+
+    **IMPORTANT DISCLAIMER**:
+
+
+    MASVS-PRIVACY is not intended to serve as an exhaustive or exclusive reference. While it provides valuable guidance on app-centric privacy considerations, it should never replace comprehensive assessments, such as a Data Protection Impact Assessment (DPIA) mandated by the General Data Protection Regulation (GDPR) or other pertinent legal and regulatory frameworks. Stakeholders are strongly advised to undertake a holistic approach to privacy, integrating MASVS-PRIVACY insights with broader assessments to ensure comprehensive data protection compliance. Given the specialized nature of privacy regulations and the complexity of data protection, these assessments are best conducted by privacy experts rather than security experts.
+
+    '
+  controls:
+  - id: MASVS-PRIVACY-1
+    statement: The app minimizes access to sensitive data and resources.
+    description: 'Apps should only request access to the data they absolutely need for their functionality and always with informed consent from the user. This control ensures that apps practice data minimization and restricts access control, reducing the potential impact of data breaches or leaks.
+
+
+      Furthermore, apps should share data with third parties only when necessary, and this should include enforcing that third-party SDKs operate based on user consent, not by default or without it. Apps should prevent third-party SDKs from ignoring consent signals or from collecting data before consent is confirmed.
+
+
+      Additionally, apps should be aware of the ''supply chain'' of SDKs they incorporate, ensuring that no data is unnecessarily passed down their chain of dependencies. This end-to-end responsibility for data aligns with recent SBOM regulatory requirements, making apps more accountable for their data practices.'
+  - id: MASVS-PRIVACY-2
+    statement: The app prevents identification of the user.
+    description: 'Protecting user identity is crucial. This control emphasizes the use of unlinkability techniques like data abstraction, anonymization and pseudonymization to prevent user identification and tracking.
+
+
+      Another key aspect addressed by this control is to establish technical barriers when employing complex ''fingerprint-like'' signals (e.g. device IDs, IP addresses, behavioral patterns) for specific purposes. For instance, a fingerprint used for fraud detection should be isolated and not repurposed for audience measurement in an analytics SDK. This ensures that each data stream serves its intended function without risking user privacy.'
+  - id: MASVS-PRIVACY-3
+    statement: The app is transparent about data collection and usage.
+    description: Users have the right to know how their data is being used. This control ensures that apps provide clear information about data collection, storage, and sharing practices, including any behavior a user wouldn't reasonably expect, such as background data collection. Apps should also adhere to platform guidelines on data declarations.
+  - id: MASVS-PRIVACY-4
+    statement: The app offers user control over their data.
+    description: Users should have control over their data. This control ensures that apps provide mechanisms for users to manage, delete, and modify their data, and change privacy settings as needed (e.g. to revoke consent). Additionally, apps should re-prompt for consent and update their transparency disclosures when they require more data than initially specified.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@ This PR covers issue #< insert number here >.
 
 ---
 
-> Note: Thank you for submitting a Pull Request to the OWASP MASVS repo! By opening a PR you're agreeing with our [contribution guidelines](https://github.com/OWASP/owasp-masvs/blob/master/CONTRIBUTING.md "Contribution guidelines").
+> Note: Thank you for submitting a Pull Request to the OWASP MASVS repo! By opening a PR you're agreeing with our [contribution guidelines](https://github.com/OWASP/masvs/blob/master/CONTRIBUTING.md "Contribution guidelines").

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 # OWASP Mobile Application Security Verification Standard (MASVS)
 
 [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship%20project-48A646.svg)](https://owasp.org/projects/)
-[![Creative Commons License](https://img.shields.io/github/license/OWASP/owasp-masvs)](https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0")
+[![Creative Commons License](https://img.shields.io/github/license/OWASP/masvs)](https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0")
 
-[![MASVS Build](https://github.com/OWASP/owasp-masvs/workflows/MASVS%20Build/badge.svg)](https://github.com/OWASP/owasp-masvs/actions/workflows/docgenerator.yml)
-[![Markdown Linter](https://github.com/OWASP/owasp-masvs/workflows/Markdown%20Linter/badge.svg)](https://github.com/OWASP/owasp-masvs/actions/workflows/markdown-linter.yml)
-[![URL Checker](https://github.com/OWASP/owasp-masvs/workflows/URL%20Checker/badge.svg)](https://github.com/OWASP/owasp-masvs/actions/workflows/url-checker.yml)
+[![MASVS Build](https://github.com/OWASP/masvs/workflows/MASVS%20Build/badge.svg)](https://github.com/OWASP/masvs/actions/workflows/docgenerator.yml)
+[![Markdown Linter](https://github.com/OWASP/masvs/workflows/Markdown%20Linter/badge.svg)](https://github.com/OWASP/masvs/actions/workflows/markdown-linter.yml)
+[![URL Checker](https://github.com/OWASP/masvs/workflows/URL%20Checker/badge.svg)](https://github.com/OWASP/masvs/actions/workflows/url-checker.yml)
 
 This is the official Github Repository of the OWASP Mobile Application Security Verification Standard (MASVS). The MASVS establishes baseline security requirements for mobile apps that are useful in many scenarios. You can use it:
 
@@ -15,7 +15,7 @@ This is the official Github Repository of the OWASP Mobile Application Security 
 - As guidance - To provide guidance during all phases of mobile app development and testing.
 - During procurement - To provide a baseline for mobile app security verification.
 
-The MASVS is a sister project of the [OWASP Mobile Application Security Testing Guide](https://github.com/OWASP/owasp-mastg "OWASP Mobile Application Security Testing Guide").
+The MASVS is a sister project of the [OWASP Mobile Application Security Testing Guide](https://github.com/OWASP/mastg "OWASP Mobile Application Security Testing Guide").
 
 <br>
 
@@ -28,8 +28,8 @@ The MASVS is a sister project of the [OWASP Mobile Application Security Testing 
 <br>
 
 - 🌐 [Access the MASVS Web](https://mas.owasp.org/MASVS/)
-- ⬇️ [Download the latest PDF](https://github.com/OWASP/owasp-masvs/releases/latest)
-- ✅ [Get the latest Mobile App Security Checklists](https://github.com/OWASP/owasp-mastg/releases/latest)
+- ⬇️ [Download the latest PDF](https://github.com/OWASP/masvs/releases/latest)
+- ✅ [Get the latest Mobile App Security Checklists](https://github.com/OWASP/mastg/releases/latest)
 - ⚡ [Contribute!](#how-to-contribute)
 - 💥 [Play with our Crackmes](https://mas.owasp.org/crackmes)
 
@@ -38,7 +38,7 @@ The MASVS is a sister project of the [OWASP Mobile Application Security Testing 
 The OWASP MASVS and MASTG are trusted by the following platform providers and standardization, governmental and educational institutions. [Learn more](https://mas.owasp.org/MASTG/0x02b-MASVS-MASTG-Adoption/).
 
 <a href="https://mas.owasp.org/MASTG/0x02b-MASVS-MASTG-Adoption/">
-<img src="https://github.com/OWASP/owasp-mastg/blob/master/Document/Images/Other/trusted-by-logos.png"/>
+<img src="https://github.com/OWASP/mastg/blob/master/Document/Images/Other/trusted-by-logos.png"/>
 </a>
 
 ## 🥇 MAS Advocates
@@ -48,8 +48,8 @@ MAS Advocates are industry adopters of the OWASP MASVS and MASTG who have invest
 <br>
 
 <a href="https://mas.owasp.org/MASTG/0x02c-Acknowledgements#our-mastg-advocates">
-<img src="https://raw.githubusercontent.com/OWASP/owasp-mastg/master/Document/Images/Other/nowsecure-logo.png" width="200px;" />
-<img src="https://raw.githubusercontent.com/OWASP/owasp-mastg/master/Document/Images/Other/guardsquare-logo.png" width="200px;" />
+<img src="https://raw.githubusercontent.com/OWASP/mastg/master/Document/Images/Other/nowsecure-logo.png" width="200px;" />
+<img src="https://raw.githubusercontent.com/OWASP/mastg/master/Document/Images/Other/guardsquare-logo.png" width="200px;" />
 </a>
 
 <br><br>
@@ -64,13 +64,13 @@ The MASVS is an open source effort and we welcome all kinds of contributions and
 
 **Help us improve & join our community:**
 
-- 🐞 [Report an error (typos, grammar)](https://github.com/OWASP/owasp-masvs/issues) or [fix it on a Pull Request](https://github.com/OWASP/owasp-masvs/pulls).
-- 💬 [Give feedback](https://github.com/OWASP/owasp-masvs/discussions/categories/general).
-- 🙏 [Ask questions](https://github.com/OWASP/owasp-masvs/discussions/categories/q-a)
+- 🐞 [Report an error (typos, grammar)](https://github.com/OWASP/masvs/issues) or [fix it on a Pull Request](https://github.com/OWASP/masvs/pulls).
+- 💬 [Give feedback](https://github.com/OWASP/masvs/discussions/categories/general).
+- 🙏 [Ask questions](https://github.com/OWASP/masvs/discussions/categories/q-a)
 
 **Contribute with content:**
 
-- 💡 [Propose ideas or suggest improvements](https://github.com/OWASP/owasp-masvs/discussions/categories/ideas) (if it qualifies we'll promote it to an [Issue](https://github.com/OWASP/owasp-masvs/issues "Github issues"))
-- 📄 [Create a Pull Request](https://github.com/OWASP/owasp-masvs/pulls) for concrete fixes (e.g. grammar/typos) or content already approved by the core team.
+- 💡 [Propose ideas or suggest improvements](https://github.com/OWASP/masvs/discussions/categories/ideas) (if it qualifies we'll promote it to an [Issue](https://github.com/OWASP/masvs/issues "Github issues"))
+- 📄 [Create a Pull Request](https://github.com/OWASP/masvs/pulls) for concrete fixes (e.g. grammar/typos) or content already approved by the core team.
 
 Before you start contributing, please check our [contribution guide](https://mas.owasp.org/contributing/) which should get you started. If you have any doubts [please contact us](#connect-with-us).

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -5,7 +5,7 @@ The MASVS document generation is based on pandocker: [https://github.com/dalibo/
 ## On your Machine
 
 - Install Docker
-- `cd` to the MASVS root folder `owasp-masvs/`
+- `cd` to the MASVS root folder `masvs/`
 - Run the `pandoc_makedocs.sh` script with the language folder and an optional version number (**do not `cd` into `tools/docker` to run it**):
 
     ```sh
@@ -27,9 +27,9 @@ The MASVS document generation is based on pandocker: [https://github.com/dalibo/
 
 ## On GitHub
 
-Each time you push to GitHub the workflows in the [MASVS GitHub Actions](https://github.com/OWASP/owasp-masvs/actions "MASVS GitHub Actions") will be triggered. You can check what will be executed inside the folder `owasp-masvs/.github/workflows`, where `docgenerator.yml` takes care of building the Docker image and running the generation script once per language inside the container.
+Each time you push to GitHub the workflows in the [MASVS GitHub Actions](https://github.com/OWASP/masvs/actions "MASVS GitHub Actions") will be triggered. You can check what will be executed inside the folder `masvs/.github/workflows`, where `docgenerator.yml` takes care of building the Docker image and running the generation script once per language inside the container.
 
-See the results in: <https://github.com/OWASP/owasp-masvs/actions>
+See the results in: <https://github.com/OWASP/masvs/actions>
 
 ## Generation Steps
 
@@ -67,4 +67,4 @@ Given a new version:
 
 ## Open Points (REMOVE from here when DONE!)
 
-Finish items for [https://github.com/OWASP/owasp-masvs/issues/361](https://github.com/OWASP/owasp-masvs/issues/361):
+Finish items for [https://github.com/OWASP/masvs/issues/361](https://github.com/OWASP/masvs/issues/361):

--- a/tools/docker/cover.tex
+++ b/tools/docker/cover.tex
@@ -2,7 +2,7 @@
 
 % The cover is created first using Google Drawings: https://docs.google.com/drawings/d/1i0NIJq3ChVrdQ-0YdqcYGeWUw9QCzd61gDBp05dP7b8/edit?usp=sharing
 % To best fit the PDF, in Google Drawings we go to "File > Page Setup" and set Width = 2480px and Height = 3508px.
-% It is exported as cover.pdf and lives in the root folder (owasp-mastg/)
+% It is exported as cover.pdf and lives in the root folder (mastg/)
 
 % The version text is written dynamically using the code in this file
 % The used latex overlay uses the coordinates (X,Y), where (0, 0) is the lower left corner of the page.

--- a/tools/docker/first_page.tex
+++ b/tools/docker/first_page.tex
@@ -6,7 +6,7 @@
 
 $masvs_version$ released \today \\
 
-Release Notes: \url{https://github.com/OWASP/owasp-masvs/releases/tag/$masvs_version$} \\ \\
+Release Notes: \url{https://github.com/OWASP/masvs/releases/tag/$masvs_version$} \\ \\
 
 
 The OWASP MASVS, available online at \url{https://mas.owasp.org/MASVS}, is part of the OWASP Mobile Application Security (MAS) Project which also provides the \href{https://mas.owasp.org/MASTG}{OWASP Mobile Application Security Testing Guide (MASTG) $mastg_version$} \\

--- a/tools/generate_masvs_cyclonedx.py
+++ b/tools/generate_masvs_cyclonedx.py
@@ -74,10 +74,10 @@ class CycloneDX:
         self.bom['definitions']['standards'][0]['externalReferences'][0]['url'] = 'https://owasp.org/masvs'
         self.bom['definitions']['standards'][0]['externalReferences'].append({})
         self.bom['definitions']['standards'][0]['externalReferences'][1]['type'] = 'vcs'
-        self.bom['definitions']['standards'][0]['externalReferences'][1]['url'] = 'https://github.com/OWASP/owasp-masvs'
+        self.bom['definitions']['standards'][0]['externalReferences'][1]['url'] = 'https://github.com/OWASP/masvs'
         self.bom['definitions']['standards'][0]['externalReferences'].append({})
         self.bom['definitions']['standards'][0]['externalReferences'][2]['type'] = 'issue-tracker'
-        self.bom['definitions']['standards'][0]['externalReferences'][2]['url'] = 'https://github.com/OWASP/owasp-masvs/issues'
+        self.bom['definitions']['standards'][0]['externalReferences'][2]['url'] = 'https://github.com/OWASP/masvs/issues'
         self.bom['definitions']['standards'][0]['externalReferences'].append({})
         self.bom['definitions']['standards'][0]['externalReferences'][3]['type'] = 'social'
         self.bom['definitions']['standards'][0]['externalReferences'][3]['url'] = 'https://twitter.com/OWASP_MAS'

--- a/tools/generate_masvs_sarif.py
+++ b/tools/generate_masvs_sarif.py
@@ -24,7 +24,7 @@ sarif_corrected_template = {
                 "releaseDateUtc": current_date_str,
                 "organization": "OWASP",
                 "informationUri": "https://mas.owasp.org/MASVS/",
-                "downloadUri": "https://github.com/OWASP/owasp-masvs/releases"
+                "downloadUri": "https://github.com/OWASP/masvs/releases"
             }
         },
         "taxonomies": [{


### PR DESCRIPTION
Update all references to the OWASP MASVS repository to use the correct name, ensuring consistency across documentation and code.